### PR TITLE
Score type

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -32,8 +32,11 @@
 #include "magic.h"
 #include "position.h"
 #include "pawnhashtable.h"
+#include "score.h"
 
 namespace {
+
+constexpr Score ZERO = Score(0);
 
 constexpr Bitboard CenterBB = make_bitboard(d4, e4, d5, e5);
 
@@ -227,8 +230,8 @@ void Evaluate<Tuning>::eval_material() {
 
   if (add)
   {
-    poseval_mg[Us] += bishop_pair_mg;
-    poseval_eg[Us] += bishop_pair_eg;
+    poseval_mg[Us] += bishop_pair.mg();
+    poseval_eg[Us] += bishop_pair.eg();
   }
 }
 
@@ -238,9 +241,8 @@ void Evaluate<Tuning>::eval_pieces() {
   static_assert(Pt != Pawn && Pt != King && Pt != NoPieceType);
   constexpr auto Them   = ~Us;
   const auto all_pieces = b.pieces();
-  auto score_mg         = 0;
-  auto score_eg         = 0;
-  auto score            = 0;
+  auto result           = ZeroScor;
+  auto score_pos            = 0;
   auto pieces           = b.pieces(Pt, Us);
   auto attacks          = ZeroBB;
 
@@ -266,71 +268,56 @@ void Evaluate<Tuning>::eval_pieces() {
 
     if constexpr (Pt == Knight)
     {
-      score_mg += knight_pst_mg[flipsq];
-      score_eg += knight_pst_eg[flipsq];
-      score_mg += knight_mob_mg[mob];
-      score_eg += knight_mob_eg[mob];
-      score_mg += knight_mob2_mg[not_defended_by_pawns];
-      score_eg += knight_mob2_eg[not_defended_by_pawns];
+      result += knight_pst[flipsq];
+      result += knight_mob[mob];
+      result += knight_mob2[not_defended_by_pawns];
 
       if (attacked_by<Them>(Pawn) & sq)
-        score -= piece_in_danger[Pt];
+        score_pos -= piece_in_danger[Pt];
 
     } else if constexpr (Pt == Bishop)
     {
-      score_mg += bishop_pst_mg[flipsq];
-      score_eg += bishop_pst_eg[flipsq];
-      score_mg += bishop_mob_mg[mob];
-      score_eg += bishop_mob_eg[mob];
-      score_mg += bishop_mob2_mg[not_defended_by_pawns];
-      score_eg += bishop_mob2_eg[not_defended_by_pawns];
+      result += bishop_pst[flipsq];
+      result += bishop_mob[mob];
+      result += bishop_mob2[not_defended_by_pawns];
 
       if (more_than_one(piece_attacks_bb<Bishop>(sq, b.pieces(Pawn, Us) | b.pieces(Pawn, Them)) & CenterBB))
-      {
-        score_mg += bishop_diagonal_mg;
-        score_eg += bishop_diagonal_eg;
-      }
+        result += bishop_diagonal;
 
       if (attacked_by<Them>(Pawn) & sq)
-        score -= piece_in_danger[Pt];
+        score_pos -= piece_in_danger[Pt];
 
     } else if constexpr (Pt == Rook)
     {
-      score_mg += rook_pst_mg[flipsq];
-      score_eg += rook_pst_eg[flipsq];
-      score_mg += rook_mob_mg[mob];
-      score_eg += rook_mob_eg[mob];
+      result += rook_pst[flipsq];
+      result += rook_mob[mob];
 
       if (open_files & sq)
-        score += rook_open_file;
+        score_pos += rook_open_file;
 
       if (attacked_by<Them>(Pawn, Knight, Bishop) & sq)
-        score -= piece_in_danger[Pt];
+        score_pos -= piece_in_danger[Pt];
 
     } else if constexpr (Pt == Queen)
     {
-      score_mg += queen_pst_mg[flipsq];
-      score_eg += queen_pst_eg[flipsq];
-      score_mg += queen_mob_mg[mob];
-      score_eg += queen_mob_eg[mob];
+      result += queen_pst[flipsq];
+      result += queen_mob[mob];
 
       if (attacked_by<Them>(Pawn, Knight, Bishop, Rook) & sq)
-        score -= piece_in_danger[Pt];
-
+        score_pos -= piece_in_danger[Pt];
     }
   }
 
-  poseval[Us] += score;
-  poseval_mg[Us] += score_mg;
-  poseval_eg[Us] += score_eg;
+  poseval[Us] += score_pos;
+  poseval_mg[Us] += result.mg();
+  poseval_eg[Us] += result.eg();
 }
 
 template<bool Tuning>
 template<Color Us>
 void Evaluate<Tuning>::eval_pawns() {
   constexpr auto Them = ~Us;
-  auto score_mg       = 0;
-  auto score_eg       = 0;
+  auto result         = ZeroScor;
 
   auto pawns = b.pieces(Pawn, Us);
 
@@ -346,25 +333,17 @@ void Evaluate<Tuning>::eval_pawns() {
     const auto open_file = !b.is_piece_on_file(Pawn, sq, Them);
 
     if (b.is_pawn_isolated(sq, Us))
-    {
-      score_mg += pawn_isolated_mg[open_file];
-      score_eg += pawn_isolated_eg[open_file];
-    } else if (b.is_pawn_behind(sq, Us))
-    {
-      score_mg += pawn_behind_mg[open_file];
-      score_eg += pawn_behind_eg[open_file];
-    }
+      result += pawn_isolated[open_file];
+    else if (b.is_pawn_behind(sq, Us))
+      result += pawn_behind[open_file];
 
     if (pawns & file)
-    {
-      score_mg += pawn_doubled_mg[open_file];
-      score_eg += pawn_doubled_eg[open_file];
-    }
-    score_mg += pawn_pst_mg[flipsq];
-    score_eg += pawn_pst_eg[flipsq];
+      result += pawn_doubled[open_file];
+
+    result += pawn_pst[flipsq];
   }
-  pawn_eval_mg[Us] += score_mg;
-  pawn_eval_eg[Us] += score_eg;
+  pawn_eval_mg[Us] += result.mg();
+  pawn_eval_eg[Us] += result.eg();
 }
 
 template<bool Tuning>
@@ -374,22 +353,24 @@ void Evaluate<Tuning>::eval_king() {
   const auto sq          = b.king_sq(Us);
   const auto bbsq        = bit(sq);
   const auto flipsq      = relative_square(~Us, sq);
-  auto score_mg          = king_pst_mg[flipsq];
-  const auto score_eg    = king_pst_eg[flipsq];
+  auto result         = king_pst[flipsq];
+  auto pos_score   = 0;
 
-  score_mg += king_pawn_shelter[std::popcount((pawn_push<Up>(bbsq) | pawn_west_attacks[Us](bbsq) | pawn_east_attacks[Us](bbsq)) & b.pieces(Pawn, Us))];
+  pos_score += king_pawn_shelter[std::popcount((pawn_push<Up>(bbsq) | pawn_west_attacks[Us](bbsq) | pawn_east_attacks[Us](bbsq)) & b.pieces(Pawn, Us))];
 
   const auto eastwest = bbsq | west_one(bbsq) | east_one(bbsq);
 
-  score_mg += king_on_open[std::popcount(open_files & eastwest)];
-  score_mg += king_on_half_open[std::popcount(half_open_files[Us] & eastwest)];
+  pos_score += king_on_open[std::popcount(open_files & eastwest)];
+  pos_score += king_on_half_open[std::popcount(half_open_files[Us] & eastwest)];
 
   if (((Us == 0) && (((sq == f1 || sq == g1) && (b.pieces(Rook, WHITE) & h1)) || ((sq == c1 || sq == b1) && (b.pieces(Rook, WHITE) & a1))))
       || ((Us == 1) && (((sq == f8 || sq == g8) && (b.pieces(Rook, BLACK) & h8)) || ((sq == c8 || sq == b8) && (b.pieces(Rook, BLACK) & a8)))))
-    score_mg += king_obstructs_rook;
+    pos_score -= king_obstructs_rook;
 
-  poseval_mg[Us] += score_mg;
-  poseval_eg[Us] += score_eg;
+  result += make_score(pos_score, 0);
+
+  poseval_mg[Us] += result.mg();
+  poseval_eg[Us] += result.eg();
 }
 
 template<bool Tuning>
@@ -400,6 +381,9 @@ void Evaluate<Tuning>::eval_passed_pawns() {
   if (pawnp == nullptr)
     return;
 
+  auto result = ZeroScor;
+  auto score_pos = 0;
+
   const auto our_pawns = b.pieces(Pawn, Us);
 
   for (auto files = pawnp->passed_pawn_file(Us); files; reset_lsb(files))
@@ -409,19 +393,19 @@ void Evaluate<Tuning>::eval_passed_pawns() {
       const auto sq         = lsb(bb);
       const auto front_span = pawn_front_span[Us][sq];
       const auto r          = relative_rank(Us, sq);
-      const auto score_mg   = passed_pawn_mg[r];
-      auto score_eg         = passed_pawn_eg[r];
+      result += passed_pawn[r];
 
-      score_eg += passed_pawn_no_us[r] * (front_span & b.pieces(Us) ? 0 : 1);
-      score_eg += passed_pawn_no_them[r] * (front_span & b.pieces(Them) ? 0 : 1);
-      score_eg += passed_pawn_no_attacks[r] * (front_span & attacked_by<Them>(AllPieceTypes) ? 0 : 1);
-      score_eg += passed_pawn_king_dist_them[distance(sq, b.king_sq(Them))];
-      score_eg += passed_pawn_king_dist_us[distance(sq, b.king_sq(Us))];
-
-      poseval_mg[Us] += score_mg;
-      poseval_eg[Us] += score_eg;
+      score_pos += passed_pawn_no_us[r] * (front_span & b.pieces(Us) ? 0 : 1);
+      score_pos += passed_pawn_no_them[r] * (front_span & b.pieces(Them) ? 0 : 1);
+      score_pos += passed_pawn_no_attacks[r] * (front_span & attacked_by<Them>(AllPieceTypes) ? 0 : 1);
+      score_pos += passed_pawn_king_dist_them[distance(sq, b.king_sq(Them))];
+      score_pos += passed_pawn_king_dist_us[distance(sq, b.king_sq(Us))];
     }
   }
+
+  result += make_score(0, score_pos);
+  poseval_mg[Us] += result.mg();
+  poseval_eg[Us] += result.eg();
 }
 
 template<bool Tuning>

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -36,26 +36,28 @@
 
 namespace {
 
-constexpr Score ZERO = Score(0);
-
-constexpr Bitboard CenterBB = make_bitboard(d4, e4, d5, e5);
-
-constexpr auto get_actual_eval = [](const std::array<int, COL_NB> &e) { return e[WHITE] - e[BLACK]; };
-
+constexpr auto get_actual_eval   = [](const std::array<int, COL_NB> &e) { return e[WHITE] - e[BLACK]; };
+constexpr Bitboard CenterBB      = make_bitboard(d4, e4, d5, e5);
 constexpr auto max_log_file_size = 1048576 * 5;
 constexpr auto max_log_files     = 3;
 
 std::shared_ptr<spdlog::logger> eval_logger = spdlog::rotating_logger_mt("eval_logger", "logs/eval.txt", max_log_file_size, max_log_files);
+
+[[nodiscard]]
+const auto get_stages(Material &mat) {
+  const auto stage = (mat.value() - mat.pawn_value()) / static_cast<double>(Material::max_value_without_pawns);
+  return std::make_pair(stage, 1 - stage);
+}
 
 }// namespace
 
 template<bool Tuning>
 struct Evaluate {
 
-  Evaluate()                      = delete;
-  ~Evaluate()                     = default;
-  Evaluate(const Evaluate &other) = delete;
-  Evaluate(Evaluate &&other)      = delete;
+  Evaluate()                            = delete;
+  ~Evaluate()                           = default;
+  Evaluate(const Evaluate &other)       = delete;
+  Evaluate(Evaluate &&other)            = delete;
   Evaluate &operator=(const Evaluate &) = delete;
   Evaluate &operator=(Evaluate &&other) = delete;
   Evaluate(const Game *g, PawnHashTable *pawntable) : b(g->board), pos(g->pos), pawnt(pawntable) {}
@@ -69,17 +71,22 @@ private:
   template<Color C, typename... PieceTypes>
   [[nodiscard]]
   Bitboard attacked_by(PieceTypes... piece_types) const noexcept;
-  void eval_pawns_both_sides();
+  [[nodiscard]]
+  Score eval_pawns_both_sides();
   template<Color Us>
   void eval_material();
   template<PieceType Pt, Color Us>
-  void eval_pieces();
+  [[nodiscard]]
+  Score eval_pieces();
   template<Color Us>
-  void eval_pawns();
+  [[nodiscard]]
+  Score eval_pawns();
   template<Color Us>
-  void eval_king();
+  [[nodiscard]]
+  Score eval_king();
   template<Color Us>
-  void eval_passed_pawns();
+  [[nodiscard]]
+  Score eval_passed_pawns() const;
   template<Color Us>
   void eval_king_attack();
   template<Color Us>
@@ -90,11 +97,8 @@ private:
   PawnHashTable *pawnt{};
   PawnHashEntry *pawnp{};
 
-  std::array<int, COL_NB> poseval_mg{};
-  std::array<int, COL_NB> poseval_eg{};
-  std::array<int, COL_NB> poseval{};
-  std::array<int, COL_NB> pawn_eval_mg{};
-  std::array<int, COL_NB> pawn_eval_eg{};
+  std::array<Score, COL_NB> poseval{};
+  std::array<int, COL_NB> posistion_value{};
   std::array<int, COL_NB> passed_pawn_files{};
   std::array<int, COL_NB> attack_counter{};
   std::array<int, COL_NB> attack_count{};
@@ -114,9 +118,9 @@ int Evaluate<Tuning>::evaluate(const int alpha, const int beta) {
   eval_material<WHITE>();
   eval_material<BLACK>();
 
-  const auto mat_eval = get_actual_eval(poseval);
-
 #if !defined(NO_EVAL_LAZY_THRESHOLD)
+
+  const auto mat_eval = get_actual_eval(posistion_value);
 
   if (const auto lazy_eval = pos->side_to_move == WHITE ? mat_eval : -mat_eval; lazy_eval - lazy_margin > beta || lazy_eval + lazy_margin < alpha)
     return pos->material.evaluate(pos->flags, lazy_eval, pos->side_to_move, &b);
@@ -124,33 +128,29 @@ int Evaluate<Tuning>::evaluate(const int alpha, const int beta) {
 #endif
 
   // Pass 1.
-  eval_pawns_both_sides();
-  eval_pieces<Knight, WHITE>();
-  eval_pieces<Knight, BLACK>();
-  eval_pieces<Bishop, WHITE>();
-  eval_pieces<Bishop, BLACK>();
-  eval_pieces<  Rook, WHITE>();
-  eval_pieces<  Rook, BLACK>();
-  eval_pieces< Queen, WHITE>();
-  eval_pieces< Queen, BLACK>();
-
-  eval_king<WHITE>();
-  eval_king<BLACK>();
+  auto result = eval_pawns_both_sides();
+  result     += eval_pieces<Knight, WHITE>() - eval_pieces<Knight, BLACK>();
+  result     += eval_pieces<Bishop, WHITE>() - eval_pieces<Bishop, BLACK>();
+  result     += eval_pieces<  Rook, WHITE>() - eval_pieces<  Rook, BLACK>();
+  result     += eval_pieces< Queen, WHITE>() - eval_pieces< Queen, BLACK>();
+  result     += eval_king<          WHITE>() - eval_king<          BLACK>();
 
   // Pass 2.
-  eval_passed_pawns<WHITE>();
-  eval_passed_pawns<BLACK>();
+  result += eval_passed_pawns<WHITE>() - eval_passed_pawns<BLACK>();
+
   eval_king_attack<WHITE>();
   eval_king_attack<BLACK>();
 
-  const auto stage = (pos->material.value() - pos->material.pawn_value()) / static_cast<double>(Material::max_value_without_pawns);
+  posistion_value[pos->side_to_move] += tempo;
 
-  poseval[pos->side_to_move] += tempo;
+  // finally add the remaining poseval scores
+  result += poseval[WHITE] - poseval[BLACK];
 
-  const auto pos_eval_mg = static_cast<int>(get_actual_eval(poseval_mg) * stage);
-  const auto pos_eval_eg = static_cast<int>(get_actual_eval(poseval_eg) * (1 - stage));
-  const auto pos_eval    = pos_eval_mg + pos_eval_eg + get_actual_eval(poseval);
-  const auto eval        = pos->material.evaluate(pos->flags, pos->side_to_move == BLACK ? -pos_eval : pos_eval, pos->side_to_move, &b);
+  const auto [stage_mg, stage_eg] = get_stages(pos->material);
+  const auto pos_eval_mg          = static_cast<int>(result.mg() * stage_mg);
+  const auto pos_eval_eg          = static_cast<int>(result.eg() * stage_eg);
+  const auto pos_eval             = pos_eval_mg + pos_eval_eg + get_actual_eval(posistion_value);
+  const auto eval                 = pos->material.evaluate(pos->flags, pos->side_to_move == BLACK ? -pos_eval : pos_eval, pos->side_to_move, &b);
 
   return eval;
 }
@@ -178,38 +178,40 @@ Bitboard Evaluate<Tuning>::attacked_by(PieceTypes... piece_types) const noexcept
 }
 
 template<bool Tuning>
-void Evaluate<Tuning>::eval_pawns_both_sides() {
+Score Evaluate<Tuning>::eval_pawns_both_sides() {
+
+  auto result = ZeroScor;
 
   if (pos->material.pawn_count() == 0)
   {
     pawnp = nullptr;
-    return;
+    return result;
   }
 
   pawnp = pawnt->find(pos);
 
   if (pawnp->zkey == 0 || pawnp->zkey != pos->pawn_structure_key)
   {
-    pawn_eval_mg.fill(0);
-    pawn_eval_eg.fill(0);
     passed_pawn_files.fill(0);
 
-    eval_pawns<WHITE>();
-    eval_pawns<BLACK>();
+    const auto w_result = eval_pawns<WHITE>();
+    const auto b_result = eval_pawns<BLACK>();
+    result   = w_result - b_result;
 
     if constexpr (!Tuning)
-      pawnp = pawnt->insert(pos->pawn_structure_key, get_actual_eval(pawn_eval_mg), get_actual_eval(pawn_eval_eg), passed_pawn_files);
-  }
-  poseval_mg[0] += pawnp->eval_mg;
-  poseval_eg[0] += pawnp->eval_eg;
+      pawnp = pawnt->insert(pos->pawn_structure_key, result, passed_pawn_files);
+  } else
+    result = pawnp->eval;
+
+  return result;
 }
 
 template<bool Tuning>
 template<Color Us>
 void Evaluate<Tuning>::eval_material() {
-  poseval[Us] = pos->material.material_value[Us];
 
-  bool add{};
+  posistion_value[Us] = pos->material.material_value[Us];
+  auto add            = false;
 
   if (const auto bishop_count = pos->material.count(Us, Bishop); bishop_count == 2)
   {
@@ -229,20 +231,18 @@ void Evaluate<Tuning>::eval_material() {
   }
 
   if (add)
-  {
-    poseval_mg[Us] += bishop_pair.mg();
-    poseval_eg[Us] += bishop_pair.eg();
-  }
+    poseval[Us] += bishop_pair;
 }
 
 template<bool Tuning>
 template<PieceType Pt, Color Us>
-void Evaluate<Tuning>::eval_pieces() {
+Score Evaluate<Tuning>::eval_pieces() {
   static_assert(Pt != Pawn && Pt != King && Pt != NoPieceType);
+
   constexpr auto Them   = ~Us;
   const auto all_pieces = b.pieces();
   auto result           = ZeroScor;
-  auto score_pos            = 0;
+  auto score_pos        = 0;
   auto pieces           = b.pieces(Pt, Us);
   auto attacks          = ZeroBB;
 
@@ -298,6 +298,15 @@ void Evaluate<Tuning>::eval_pieces() {
       if (attacked_by<Them>(Pawn, Knight, Bishop) & sq)
         score_pos -= piece_in_danger[Pt];
 
+      if (mob <= 3)
+      {
+        const auto king_file = file_of(b.king_sq(Us));
+        if ((king_file < FILE_E) == (file_of(sq) < king_file))
+        {
+          const auto modifier = 1 + (Us & !pos->castle_rights);
+          result += king_obstructs_rook * modifier;
+        }
+      }
     } else if constexpr (Pt == Queen)
     {
       result += queen_pst[flipsq];
@@ -308,24 +317,25 @@ void Evaluate<Tuning>::eval_pieces() {
     }
   }
 
-  poseval[Us] += score_pos;
-  poseval_mg[Us] += result.mg();
-  poseval_eg[Us] += result.eg();
+  posistion_value[Us] += score_pos;
+
+  return result;
 }
 
 template<bool Tuning>
 template<Color Us>
-void Evaluate<Tuning>::eval_pawns() {
+Score Evaluate<Tuning>::eval_pawns() {
   constexpr auto Them = ~Us;
   auto result         = ZeroScor;
-
-  auto pawns = b.pieces(Pawn, Us);
+  auto pawns          = b.pieces(Pawn, Us);
 
   while (pawns)
   {
     const auto sq     = pop_lsb(&pawns);
     const auto file   = file_of(sq);
     const auto flipsq = relative_square(Them, sq);
+
+    result += pawn_pst[flipsq];
 
     if (b.is_pawn_passed(sq, Us))
       passed_pawn_files[Us] |= 1 << file;
@@ -339,51 +349,42 @@ void Evaluate<Tuning>::eval_pawns() {
 
     if (pawns & file)
       result += pawn_doubled[open_file];
-
-    result += pawn_pst[flipsq];
   }
-  pawn_eval_mg[Us] += result.mg();
-  pawn_eval_eg[Us] += result.eg();
+  return result;
 }
 
 template<bool Tuning>
 template<Color Us>
-void Evaluate<Tuning>::eval_king() {
+Score Evaluate<Tuning>::eval_king() {
   constexpr Direction Up = Us == WHITE ? NORTH : SOUTH;
   const auto sq          = b.king_sq(Us);
   const auto bbsq        = bit(sq);
   const auto flipsq      = relative_square(~Us, sq);
-  auto result         = king_pst[flipsq];
-  auto pos_score   = 0;
+  auto result            = king_pst[flipsq];
+  auto pos_score         = 0;
 
   pos_score += king_pawn_shelter[std::popcount((pawn_push<Up>(bbsq) | pawn_west_attacks[Us](bbsq) | pawn_east_attacks[Us](bbsq)) & b.pieces(Pawn, Us))];
 
-  const auto eastwest = bbsq | west_one(bbsq) | east_one(bbsq);
+  const auto east_west = bbsq | west_one(bbsq) | east_one(bbsq);
 
-  pos_score += king_on_open[std::popcount(open_files & eastwest)];
-  pos_score += king_on_half_open[std::popcount(half_open_files[Us] & eastwest)];
+  pos_score += king_on_open[std::popcount(open_files & east_west)];
+  pos_score += king_on_half_open[std::popcount(half_open_files[Us] & east_west)];
 
-  if (((Us == 0) && (((sq == f1 || sq == g1) && (b.pieces(Rook, WHITE) & h1)) || ((sq == c1 || sq == b1) && (b.pieces(Rook, WHITE) & a1))))
-      || ((Us == 1) && (((sq == f8 || sq == g8) && (b.pieces(Rook, BLACK) & h8)) || ((sq == c8 || sq == b8) && (b.pieces(Rook, BLACK) & a8)))))
-    pos_score -= king_obstructs_rook;
+  result += pos_score;
 
-  result += make_score(pos_score, 0);
-
-  poseval_mg[Us] += result.mg();
-  poseval_eg[Us] += result.eg();
+  return result;
 }
 
 template<bool Tuning>
 template<Color Us>
-void Evaluate<Tuning>::eval_passed_pawns() {
+Score Evaluate<Tuning>::eval_passed_pawns() const {
   constexpr auto Them = ~Us;
+  auto result         = ZeroScor;
 
   if (pawnp == nullptr)
-    return;
+    return result;
 
-  auto result = ZeroScor;
-  auto score_pos = 0;
-
+  auto score_pos       = 0;
   const auto our_pawns = b.pieces(Pawn, Us);
 
   for (auto files = pawnp->passed_pawn_file(Us); files; reset_lsb(files))
@@ -403,16 +404,16 @@ void Evaluate<Tuning>::eval_passed_pawns() {
     }
   }
 
-  result += make_score(0, score_pos);
-  poseval_mg[Us] += result.mg();
-  poseval_eg[Us] += result.eg();
+  result += Score(0, score_pos);
+
+  return result;
 }
 
 template<bool Tuning>
 template<Color Us>
 void Evaluate<Tuning>::eval_king_attack() {
   if (attack_count[Us] > 1)
-    poseval_mg[Us] += attack_counter[Us] * (attack_count[Us] - 1);
+    poseval[Us] += attack_counter[Us] * (attack_count[Us] - 1);
 }
 
 template<bool Tuning>
@@ -421,9 +422,7 @@ void Evaluate<Tuning>::init_evaluate() {
 
   constexpr auto Them    = ~Us;
   pos->flags             = 0;
-  poseval[Us]            = 0;
-  poseval_mg[Us]         = 0;
-  poseval_eg[Us]         = 0;
+  posistion_value[Us]    = 0;
   attack_count[Us]       = 0;
   attack_counter[Us]     = 0;
   const auto ksq         = b.king_sq(Us);
@@ -432,6 +431,8 @@ void Evaluate<Tuning>::init_evaluate() {
   const auto their_pawns = b.pieces(Pawn, Them);
   open_files             = ~(pawn_fill[Us](pawn_fill[Them](our_pawns)) | pawn_fill[Us](pawn_fill[Them](their_pawns)));
   half_open_files[Us]    = ~north_fill(south_fill(our_pawns)) & ~open_files;
+
+  poseval.fill(ZeroScor);
 
   set_attacks<Pawn, Us>(pawn_east_attacks[Us](our_pawns) | pawn_west_attacks[Us](our_pawns));
   set_attacks<King, Us>(attacks);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -173,9 +173,9 @@ int Material::evaluate(int &flags, const int eval, const Color side_to_move, con
     if (const auto drawish_score = score / drawish; pc1 + pc2 == 0)
       score = drawish_score;
     else if (pc1 == 0)
-      score = std::min(drawish_score, score);
+      score = std::min<int>(drawish_score, score);
     else if (pc2 == 0)
-      score = std::max(drawish_score, score);
+      score = std::max<int>(drawish_score, score);
   }
 
   flags = material_flags;

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <array>
+
+#include "score.h"
 #include "types.h"
 
 // TODO : Join eg and mg values into a single int (or simular)
@@ -43,118 +45,133 @@ inline std::array<int, PieceType_Nb> piece_in_danger
 // Pawn  Knight  Bishop  Rook  Queen  King
 };
 
-inline std::array<int, 14> bishop_mob2_eg{-60, -27, -20, -10, -8, -2, 2, 3, 4, 1, 6, 10, 16, 3};
-inline std::array<int, 14> bishop_mob2_mg{-27, -14, -6, -1, 3, 7, 5, 7, 11, 15, 10, 18, 12, 29};
-inline std::array<int, 14> bishop_mob_eg {-35, -20, -29, -20, -13, -6, -4, 0, 5, 8, -1, 5, 7, 2};
-inline std::array<int, 14> bishop_mob_mg {-23, -17, -13, -13, -6, 0, 5, 5, 10, 3, 2, 6, -14, 16};
+inline std::array<Score, 14> bishop_mob2 {
+  Score(-27, -60), Score(-14, -27), Score(-6, -20), Score(-1, -10), Score( 3, -8), Score( 7, -2), Score( 5, 2),
+  Score(  7,   3), Score( 11,   4), Score(15,   1), Score(10,   6), Score(18, 10), Score(12, 16), Score(29, 3)
+};
 
-inline int bishop_pair_eg     = 57;
-inline int bishop_pair_mg     = 29;
+inline std::array<Score, 14> bishop_mob {
+  Score(-23, -35), Score(-17, -20), Score(-13, -29), Score(-13, -20), Score(-6, -13), Score(  0, -6), Score( 5, -4),
+  Score(  5,   0), Score( 10,   5), Score(  3,   8), Score(  2,  -1), Score( 6,   5), Score(-14,  7), Score(16,  2)
+};
 
-inline int bishop_diagonal_eg = 0;
-inline int bishop_diagonal_mg = 45;
+inline Score bishop_pair     = Score(29, 57);
+inline Score bishop_diagonal = Score(45,  0);
 
-inline int king_obstructs_rook  = -49;
+inline int king_obstructs_rook  = 49;
+
 inline std::array<int, 4> king_on_half_open{12, -9, -55, -97};
 inline std::array<int, 4> king_on_open     {29, -13, -63, -221};
 inline std::array<int, 4> king_pawn_shelter{-20, 1, 6, -7};
 
-inline std::array<int, 9> knight_mob2_eg{-137, -56, -38, -17, -7, 0, 0, -5, -15};
-inline std::array<int, 9> knight_mob2_mg{-59, -41, -21, -10, 1, 8, 14, 22, 24};
-inline std::array<int, 9> knight_mob_eg {-40, 8, 14, 0, -5, -9, -10, -15, -8};
-inline std::array<int, 9> knight_mob_mg {76, 23, 5, 3, 3, -2, -6, -14, -16};
+inline std::array<Score, 9> knight_mob2 {
+  Score(-59, -137), Score(-41, -56), Score(-21, -38),
+  Score(-10,  -17), Score(  1,  -7), Score(  8,   0),
+  Score( 14,    0), Score( 22,  -5), Score( 24, -15)
+};
 
-inline std::array<int, 8> passed_pawn_eg             {0, -16, -7, 2, 12, 13, -115, 0};
-inline std::array<int, 8> passed_pawn_king_dist_them {0, -66, -24, 5, 22, 33, 39, 21};
-inline std::array<int, 8> passed_pawn_king_dist_us   {0, 23, 24, 0, -10, -11, 0, -17};
-inline std::array<int, 8> passed_pawn_mg             {0, -16, -16, -12, 23, 68, 95, 0};
-inline std::array<int, 8> passed_pawn_no_attacks     {0, 3, 3, 13, 24, 48, 85, 0};
-inline std::array<int, 8> passed_pawn_no_them        {0, 2, 6, 22, 36, 64, 129, 0};
-inline std::array<int, 8> passed_pawn_no_us          {0, 0, -1, 3, 17, 32, 121, 0};
+inline std::array<Score, 9> knight_mob {
+  Score(76, -40), Score( 23,   8), Score(  5, 14),
+  Score( 3,   0), Score(  3,  -5), Score( -2, -9),
+  Score(-6, -10), Score(-14, -15), Score(-16, -8)
+};
 
-inline std::array<int, 2> pawn_behind_eg           {4, -8};
-inline std::array<int, 2> pawn_behind_mg           {-4, -28};
-inline std::array<int, 2> pawn_doubled_eg          {-20, -15};
-inline std::array<int, 2> pawn_doubled_mg          {-15, 1};
-inline std::array<int, 2> pawn_isolated_eg         {-7, -32};
-inline std::array<int, 2> pawn_isolated_mg         {-13, -28};
+inline std::array<Score, 8> passed_pawn {
+  Score(0, 0), Score(-16, -16), Score(-16, -7), Score(-12, 2), Score(23, 12), Score(68, 13), Score(95, -115), Score(0, 0),
+};
+
+inline std::array<int, 8> passed_pawn_king_dist_them {0, -66, -24,  5,  22,  33,  39,  21};
+inline std::array<int, 8> passed_pawn_king_dist_us   {0,  23,  24,  0, -10, -11,   0, -17};
+inline std::array<int, 8> passed_pawn_no_attacks     {0,   3,   3, 13,  24,  48,  85,   0};
+inline std::array<int, 8> passed_pawn_no_them        {0,   2,   6, 22,  36,  64, 129,   0};
+inline std::array<int, 8> passed_pawn_no_us          {0,   0,  -1,  3,  17,  32, 121,   0};
+
+inline std::array<Score, 2> pawn_behind   { Score( -4,   4), Score(-28,  -8)};
+inline std::array<Score, 2> pawn_doubled  { Score(-15, -20), Score(  1, -15)};
+inline std::array<Score, 2> pawn_isolated { Score(-13,  -7), Score(-28, -32)};
 
 inline int queen_attack_king = 39;
-inline std::array<int, 28> queen_mob_eg {-3, -30, -17, -27, -36, -37, -30, -24, -27, -21, -17, -11, -1, 4, 2, 5, 2, 6, 3, 1, -15, -16, -15, -34, -34, -28, -12, -16};
-inline std::array<int, 28> queen_mob_mg {-19, -34, -15, -15, -13, -10, -10, -11, -6, -1, 2, -1, -3, 2, 3, 5, 7, 3, 9, 13, 25, 34, 33, 58, 44, 41, 14, 19};
+
+inline std::array<Score, 28> queen_mob {
+  Score(-19,  -3), Score(-34, -30), Score(-15, -17), Score(-15, -27), Score(-13, -36), Score(-10, -37), Score(-10, -30),
+  Score(-11, -24), Score( -6, -27), Score( -1, -21), Score(  2, -17), Score( -1, -11), Score( -3,  -1), Score(  2,   4),
+  Score(  3,   2), Score(  5,   5), Score(  7,   2), Score(  3,   6), Score(  9,   3), Score( 13,   1), Score( 25, -15),
+  Score( 34, -16), Score( 33, -15), Score( 58, -34), Score( 44, -34), Score( 41, -28), Score( 14, -12), Score( 19, -16)
+};
+
 inline int rook_attack_king  = 11;
-inline std::array<int, 15> rook_mob_eg {-46, -28, -24, -9, -5, -2, 5, 9, 14, 19, 21, 27, 27, 15, 3};
-inline std::array<int, 15> rook_mob_mg {-28, -20, -13, -16, -17, -10, -9, -3, -1, 2, 4, 1, 6, 20, 28};
+
+inline std::array<Score, 15> rook_mob {
+  Score(-28, -46), Score(-20, -28), Score(-13, -24), Score(-16, -9), Score(-17, -5),
+  Score(-10,  -2), Score( -9,   5), Score( -3,   9), Score( -1, 14), Score(  2, 19),
+  Score(  4,  21), Score(  1,  27), Score(  6,  27), Score( 20, 15), Score( 28,  3)
+};
+
 inline int rook_open_file    = 13;
 
-inline std::array<int, 64> bishop_pst_eg{7, 13,  12,  10,  24,  -5,  -19, -14, 2,   9,   3,   16,  -1,  -7,  -5,  -21, -8,  7,   4,   -17, 12,  -5,
-                               1, -19, -7,  3,   -6,  5,   7,   6,   -11, -3,  -18, -16, 7,   2,   -7,  -6,  -13, -22, -23, -19, -15, -5,
-                               2, -10, -14, -16, -33, -36, -34, -15, -16, -33, -26, -64, -46, -36, -27, -15, -26, -16, -63, -38};
-inline std::array<int, 64> bishop_pst_mg{-65, -58, -27, -41, -46, -70, 15, -35, -40, -26, -43, -25, -39, -10, -46, -59, -5,  -3,  2,   13, 22, 64,
-                               29,  4,   -27, -3,  7,   41,  14, 14,  -5,  -24, -3,  -12, 2,   17,  24,  -3,  2,   -8,  -19, 7,  0,  6,
-                               2,   5,   4,   9,   7,   0,   12, -13, 1,   16,  25,  16,  -5,  20,  -23, -23, -14, -14, -8,  -23};
-inline std::array<int, 64> king_pst_eg{-116, -11, 13, -34, -25, 22, 18, -136, -45, 40, 26, 16, 17, 36, 51, -75, 18,  41, 40, 35, 25, 33, 52, -5,  -8,  24,  34,  36, 31,  38, 23,  -4,
-                             -25,  5,   17, 24,  32,  25, 7,  -20,  -31, -5, 8,  15, 25, 21, 2,  -19, -22, -9, -2, 5,  12, 13, -5, -27, -44, -35, -16, 2,  -20, -8, -38, -66};
-inline std::array<int, 64> king_pst_mg{-83, 106, 122, 137, 123, 72,  44, -34, -2,  67,  37,  44, 43,  27, -13, -60, -44, 47,  7,   17, -2,  12,
-                             16,  -47, -16, 52,  21,  -12, -1, 5,   30,  -69, -23, 25, 6,   7,  -15, -15, -14, -63, -49, 16, -13, -12,
-                             -24, -37, -10, -53, -12, -14, 6,  -40, -36, -32, 13,  0,  -52, 16, 0,   -73, -34, -50, 32,  7};
-inline std::array<int, 64> knight_pst_eg{-33, -12, 0,   -25, -30, -18, -14, -54, -31, -16, -15, -14, -3,   -40, -21, -22, -37, -17, -3,  3,   -12, -13,
-                               -22, -28, -32, -11, -1,  15,  16,  5,   -10, -26, -28, -10, 3,    10,  9,   10,  -11, -27, -54, -28, -19, -5,
-                               -5,  -24, -37, -29, -60, -37, -40, -34, -37, -34, -29, -48, -159, -75, -46, -30, -46, -52, -67, -37};
-inline std::array<int, 64> knight_pst_mg{-221, -103, -59, -11, 38,  -31, -103, -255, -66, -40, 5,   23,  37,   35,  -11, -32, -22, -3,  42,  39,  75, 115,
-                               10,   -33,  -23, 6,   39,  66,  19,   61,   11,  25,  -25, -13, 15,   19,  32,  11,  26,  -6,  -39, -27, -8, 4,
-                               20,   1,    -4,  -40, -46, -54, -31,  -8,   -14, -20, -39, -13, -104, -44, -54, -53, -22, -24, -59, -2};
-inline std::array<int, 64> pawn_pst_eg{0,  0,  0,  0, 0, 0, 0, 0, 0,  24, 49, 29, 34, 54, 74, 26, 33, 39, 28, 15, 21, 13, 20, 6,  31, 25, 19, 1, 2, -2, 9, 13,
-                             18, 18, 12, 5, 4, 8, 5, 2, 13, 9,  10, 9,  12, 7,  -4, -4, 17, 9,  15, 12, 26, 11, -6, -2, 0,  0,  0,  0, 0, 0,  0, 0};
+inline std::array<Score, 64> bishop_pst {
+  Score(-65,   7), Score(-58,  13), Score(-27,  12), Score(-41,  10), Score(-46,  24), Score(-70,  -5), Score( 15, -19), Score(-35, -14),
+  Score(-40,   2), Score(-26,   9), Score(-43,   3), Score(-25,  16), Score(-39,  -1), Score(-10,  -7), Score(-46,  -5), Score(-59, -21),
+  Score( -5,  -8), Score( -3,   7), Score(  2,   4), Score( 13, -17), Score( 22,  12), Score( 64,  -5), Score( 29,   1), Score(  4, -19),
+  Score(-27,  -7), Score( -3,   3), Score(  7,  -6), Score( 41,   5), Score( 14,   7), Score( 14,   6), Score( -5, -11), Score(-24,  -3),
+  Score( -3, -18), Score(-12, -16), Score(  2,   7), Score( 17,   2), Score( 24,  -7), Score( -3,  -6), Score(  2, -13), Score( -8, -22),
+  Score(-19, -23), Score(  7, -19), Score(  0, -15), Score(  6,  -5), Score(  2,   2), Score(  5, -10), Score(  4, -14), Score(  9, -16),
+  Score(  7, -33), Score(  0, -36), Score( 12, -34), Score(-13, -15), Score(  1, -16), Score( 16, -33), Score( 25, -26), Score( 16, -64),
+  Score( -5, -46), Score( 20, -36), Score(-23, -27), Score(-23, -15), Score(-14, -26), Score(-14, -16), Score( -8, -63), Score(-23, -38)
+};
 
-inline std::array<int, 64> pawn_pst_mg
-       {  0,   0,   0,   0,   0,   0,  0,   0,
-        206, 124,  96, 113,  98,  36,  9,  13,
-         19,  25,  43,  36,  58,  77, 64,  30,
-         10,  16,   9,  25,  23,  12, -4,  -7,
-          0,   4,   9,  10,  11,   6,  0, -11,
-          0,  -1,  -3,   8,   9,   6, 18,  -4,
-         -7, -11, -14, -11, -14,  23, 29, -16,
-          0,   0,   0,   0,   0,   0,  0,   0};
+inline std::array<Score, 64> king_pst {
+  Score(-83, -116), Score(106, -11), Score(122,  13), Score(137, -34), Score(123, -25), Score( 72, 22), Score( 44,  18), Score(-34, -136),
+  Score( -2,  -45), Score( 67,  40), Score( 37,  26), Score( 44,  16), Score( 43,  17), Score( 27, 36), Score(-13,  51), Score(-60,  -75),
+  Score(-44,   18), Score( 47,  41), Score(  7,  40), Score( 17,  35), Score( -2,  25), Score( 12, 33), Score( 16,  52), Score(-47,   -5),
+  Score(-16,   -8), Score( 52,  24), Score( 21,  34), Score(-12,  36), Score( -1,  31), Score(  5, 38), Score( 30,  23), Score(-69,   -4),
+  Score(-23,  -25), Score( 25,   5), Score(  6,  17), Score(  7,  24), Score(-15,  32), Score(-15, 25), Score(-14,   7), Score(-63,  -20),
+  Score(-49,  -31), Score( 16,  -5), Score(-13,   8), Score(-12,  15), Score(-24,  25), Score(-37, 21), Score(-10,   2), Score(-53,  -19),
+  Score(-12,  -22), Score(-14,  -9), Score(  6,  -2), Score(-40,   5), Score(-36,  12), Score(-32, 13), Score( 13,  -5), Score(  0,  -27),
+  Score(-52,  -44), Score( 16, -35), Score(  0, -16), Score(-73,   2), Score(-34, -20), Score(-50, -8), Score( 32, -38), Score(  7,  -66)
+};
 
-inline std::array<int, 64> queen_pst_eg
-       {  5,  14,  10,  23,  20,   2,    9,    8,
-          5,  40,  40,  38,  49,  25,   25,   10,
-        -22,   7,  38,  37,  40,  20,    2,   12,
-        -10,  -5,  24,  45,  46,  32,   38,    5,
-        -32,  -5,  -2,  23,  17,   4,   -3,    3,
-        -50, -42, -20, -36, -18, -24,  -25,  -39,
-        -73, -47, -64, -61, -57, -97, -108,  -64,
-        -89, -85, -67, -61, -84, -96, -123, -110};
+inline std::array<Score, 64> knight_pst {
+  Score(-221,  -33), Score(-103, -12), Score(-59,   0), Score(-11, -25), Score( 38, -30), Score(-31, -18), Score(-103, -14), Score(-255, -54),
+  Score( -66,  -31), Score( -40, -16), Score(  5, -15), Score( 23, -14), Score( 37,  -3), Score( 35, -40), Score( -11, -21), Score( -32, -22),
+  Score( -22,  -37), Score(  -3, -17), Score( 42,  -3), Score( 39,   3), Score( 75, -12), Score(115, -13), Score(  10, -22), Score( -33, -28),
+  Score( -23,  -32), Score(   6, -11), Score( 39,  -1), Score( 66,  15), Score( 19,  16), Score( 61,   5), Score(  11, -10), Score(  25, -26),
+  Score( -25,  -28), Score( -13, -10), Score( 15,   3), Score( 19,  10), Score( 32,   9), Score( 11,  10), Score(  26, -11), Score(  -6, -27),
+  Score( -39,  -54), Score( -27, -28), Score( -8, -19), Score(  4,  -5), Score( 20,  -5), Score(  1, -24), Score(  -4, -37), Score( -40, -29),
+  Score( -46,  -60), Score( -54, -37), Score(-31, -40), Score( -8, -34), Score(-14, -37), Score(-20, -34), Score( -39, -29), Score( -13, -48),
+  Score(-104, -159), Score( -44, -75), Score(-54, -46), Score(-53, -30), Score(-22, -46), Score(-24, -52), Score( -59, -67), Score(  -2, -37)
+};
 
-inline std::array<int, 64> queen_pst_mg
-       {-10,   4,  10,  13,  14,  86,  64,  57,
-        -36, -60, -31, -10, -10,  43,   5,  39,
-         -9, -17, -14,  -4,  36,  63,  69,  16,
-        -34, -28, -30, -20, -16,  -6,   7,  -8,
-        -22, -17, -15, -16, -10, -13,   4, -13,
-        -21,  -4, -10, -13,  -4,   7,   6,  -9,
-        -14,  -3,   2,   4,   3,  26,  16, -12,
-          8,  -8,  -5,   4,   5, -18, -58,  -9};
+inline std::array<Score, 64> pawn_pst {
+  Score(  0,  0), Score(  0,  0), Score(  0,  0), Score(  0,  0), Score(  0,  0), Score( 0,  0), Score( 0,  0), Score(  0,  0),
+  Score(206,  0), Score(124, 24), Score( 96, 49), Score(113, 29), Score( 98, 34), Score(36, 54), Score( 9, 74), Score( 13, 26),
+  Score( 19, 33), Score( 25, 39), Score( 43, 28), Score( 36, 15), Score( 58, 21), Score(77, 13), Score(64, 20), Score( 30,  6),
+  Score( 10, 31), Score( 16, 25), Score(  9, 19), Score( 25,  1), Score( 23,  2), Score(12, -2), Score(-4,  9), Score( -7, 13),
+  Score(  0, 18), Score(  4, 18), Score(  9, 12), Score( 10,  5), Score( 11,  4), Score( 6,  8), Score( 0,  5), Score(-11,  2),
+  Score(  0, 13), Score( -1,  9), Score( -3, 10), Score(  8,  9), Score(  9, 12), Score( 6,  7), Score(18, -4), Score( -4, -4),
+  Score( -7, 17), Score(-11,  9), Score(-14, 15), Score(-11, 12), Score(-14, 26), Score(23, 11), Score(29, -6), Score(-16, -2),
+  Score(  0,  0), Score(  0,  0), Score(  0,  0), Score(  0,  0), Score(  0,  0), Score( 0,  0), Score( 0,  0), Score(  0,  0)
+};
 
-inline std::array<int, 64> rook_pst_eg
-       { 46,  47,  33,  28,  36,  42,  37, 29,
-         44,  41,  28,  23,  20,  22,  20, 16,
-         49,  27,  28,  10,  12,  21,  13, 32,
-         40,  35,  23,  14,  13,  21,  20, 18,
-         28,  34,  23,  11,  10,  17,  11, 19,
-         16,  14,   1,  -6, -11,  -1,  -1,  3,
-        -12,  -8, -12, -24, -23, -19, -21, -6,
-        -13, -15, -12, -20, -26, -16, -11, -19};
+inline std::array<Score, 64> queen_pst {
+  Score(-10,   5), Score(  4,  14), Score( 10,  10), Score( 13,  23), Score( 14,  20), Score( 86,   2), Score( 64,    9), Score( 57,    8),
+  Score(-36,   5), Score(-60,  40), Score(-31,  40), Score(-10,  38), Score(-10,  49), Score( 43,  25), Score( 5,    25), Score( 39,   10),
+  Score( -9, -22), Score(-17,   7), Score(-14,  38), Score( -4,  37), Score( 36,  40), Score( 63,  20), Score( 69,    2), Score( 16,   12),
+  Score(-34, -10), Score(-28,  -5), Score(-30,  24), Score(-20,  45), Score(-16,  46), Score( -6,  32), Score(  7,   38), Score( -8,    5),
+  Score(-22, -32), Score(-17,  -5), Score(-15,  -2), Score(-16,  23), Score(-10,  17), Score(-13,   4), Score(  4,   -3), Score(-13,    3),
+  Score(-21, -50), Score( -4, -42), Score(-10, -20), Score(-13, -36), Score( -4, -18), Score(  7, -24), Score(  6,  -25), Score( -9,  -39),
+  Score(-14, -73), Score( -3, -47), Score(  2, -64), Score(  4, -61), Score(  3, -57), Score( 26, -97), Score( 16, -108), Score(-12,  -64),
+  Score(  8, -89), Score( -8, -85), Score( -5, -67), Score(  4, -61), Score(  5, -84), Score(-18, -96), Score(-58, -123), Score( -9, -110)
+};
 
-inline std::array<int, 64> rook_pst_mg
-       {  1,   3,  25,  31,  24,  24, 35,  54,
-          3,  -8,  28,  40,  39,  56, 45,  39,
-        -18,   8,  14,  31,  59,  67, 51,  11,
-        -41, -23,   4,  20,  16,  17, 24, -11,
-        -46, -43, -26, -16, -22, -23, -7, -45,
-        -48, -35, -33, -31, -10, -21, -6, -25,
-        -45, -33, -18,  -4,  -3, -10, -7, -68,
-        -16,  -9,   0,   3,   7,   4,  8, -18};
-
+inline std::array<Score, 64> rook_pst {
+  Score(  1,  46), Score(  3,  47), Score( 25,  33), Score( 31,  28), Score( 24,  36), Score( 24,  42), Score(35,  37), Score( 54,  29),
+  Score(  3,  44), Score( -8,  41), Score( 28,  28), Score( 40,  23), Score( 39,  20), Score( 56,  22), Score(45,  20), Score( 39,  16),
+  Score(-18,  49), Score(  8,  27), Score( 14,  28), Score( 31,  10), Score( 59,  12), Score( 67,  21), Score(51,  13), Score( 11,  32),
+  Score(-41,  40), Score(-23,  35), Score(  4,  23), Score( 20,  14), Score( 16,  13), Score( 17,  21), Score(24,  20), Score(-11,  18),
+  Score(-46,  28), Score(-43,  34), Score(-26,  23), Score(-16,  11), Score(-22,  10), Score(-23,  17), Score(-7,  11), Score(-45,  19),
+  Score(-48,  16), Score(-35,  14), Score(-33,   1), Score(-31,  -6), Score(-10, -11), Score(-21,  -1), Score(-6,  -1), Score(-25,   3),
+  Score(-45, -12), Score(-33,  -8), Score(-18, -12), Score( -4, -24), Score( -3, -23), Score(-10, -19), Score(-7, -21), Score(-68,  -6),
+  Score(-16, -13), Score( -9, -15), Score(  0, -12), Score(  3, -20), Score(  7, -26), Score(  4, -16), Score( 8, -11), Score(-18, -19)
+};
 // clang-format on

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -55,10 +55,9 @@ inline std::array<Score, 14> bishop_mob {
   Score(  5,   0), Score( 10,   5), Score(  3,   8), Score(  2,  -1), Score( 6,   5), Score(-14,  7), Score(16,  2)
 };
 
-inline Score bishop_pair     = Score(29, 57);
-inline Score bishop_diagonal = Score(45,  0);
-
-inline int king_obstructs_rook  = 49;
+inline Score bishop_pair         = Score(29, 57);
+inline Score bishop_diagonal     = Score(45,  0);
+inline Score king_obstructs_rook = Score(49, 9);
 
 inline std::array<int, 4> king_on_half_open{12, -9, -55, -97};
 inline std::array<int, 4> king_on_open     {29, -13, -63, -221};

--- a/src/pawnhashtable.cpp
+++ b/src/pawnhashtable.cpp
@@ -27,11 +27,10 @@ PawnHashEntry *PawnHashTable::find(const Position *pos) {
   return (*this)[pos->pawn_structure_key];
 }
 
-PawnHashEntry *PawnHashTable::insert(const Key key, const int score_mg, const int score_eg, const std::array<int, 2> &passed_pawn_files) {
+PawnHashEntry *PawnHashTable::insert(const Key key, const Score s, const std::array<int, 2> &passed_pawn_files) {
   auto *pawnp    = (*this)[key];
   pawnp->zkey    = key;
-  pawnp->eval_mg = static_cast<int16_t>(score_mg);
-  pawnp->eval_eg = static_cast<int16_t>(score_eg);
+  pawnp->eval    = s;
   std::copy(passed_pawn_files.begin(), passed_pawn_files.end(), pawnp->passed_pawn_files.begin());
   return pawnp;
 }

--- a/src/pawnhashtable.h
+++ b/src/pawnhashtable.h
@@ -24,6 +24,7 @@
 
 #include "types.h"
 #include "hash.h"
+#include "score.h"
 
 struct Position;
 
@@ -33,8 +34,7 @@ struct PawnHashEntry final {
   Bitboard passed_pawn_file(const Color c) { return static_cast<Bitboard>(passed_pawn_files[c]); }
 
   Key zkey;
-  int16_t eval_mg;
-  int16_t eval_eg;
+  Score eval;
   std::array<uint8_t, COL_NB> passed_pawn_files;
   int16_t unused;
 };
@@ -45,5 +45,5 @@ struct PawnHashTable final : Table<PawnHashEntry, 512 * sizeof(PawnHashEntry)> {
   PawnHashEntry *find(const Position *pos);
 
   [[nodiscard]]
-  PawnHashEntry *insert(Key key, int score_mg, int score_eg, const std::array<int, 2> &passed_pawn_files);
+  PawnHashEntry *insert(Key key, Score s, const std::array<int, 2> &passed_pawn_files);
 };

--- a/src/score.h
+++ b/src/score.h
@@ -29,14 +29,20 @@
 
 struct Score final {
 
+  [[nodiscard]]
+  constexpr Score() = default;
+  [[nodiscard]]
   constexpr Score(const int mg, const int eg) : value(static_cast<int>(static_cast<unsigned int>(eg) << 16) + mg) {}
+  [[nodiscard]]
   constexpr Score(const int v) : value(v) {}
 
+  [[nodiscard]]
   constexpr Score &operator=(const int v) noexcept {
     value = v;
     return *this;
   }
 
+  [[nodiscard]]
   constexpr bool operator==(const Score &b) const { return value == b.value; }
 
   [[nodiscard]]
@@ -60,22 +66,54 @@ struct Score final {
   [[nodiscard]]
   constexpr int raw() const noexcept { return value; }
 
+  [[nodiscard]]
+  constexpr int combine() const noexcept { return mg() - eg(); }
+
 private:
   int value{};
 };
 
 constexpr Score ZeroScor = Score(0);
 
-constexpr Score operator+(const Score d1, const int d2) noexcept { return d1.raw() + d2; }
-constexpr Score operator-(const Score d1, const int d2) noexcept { return d1.raw() - d2; }
-constexpr Score operator-(const Score d) noexcept { return -d.raw(); }
-constexpr Score& operator+=(Score& d1, const int d2) noexcept { return d1 = d1.raw() + d2; }
-constexpr Score& operator-=(Score& d1, const int d2) noexcept { return d1 = d1.raw() - d2; }
-constexpr Score &operator+=(Score &d1, const Score d2) noexcept { return d1 = d1.raw() + d2.raw(); }
-constexpr Score &operator-=(Score &d1, const Score d2) noexcept { return d1 = d1.raw() - d2.raw(); }
+// TODO : Move some operators inside Score
+
+constexpr Score operator+(const Score d1, const int d2) noexcept {
+  return d1.raw() + d2;
+}
+
+constexpr Score operator-(const Score d1, const int d2) noexcept {
+  return d1.raw() - d2;
+}
+
+constexpr Score operator-(const Score d1, const Score d2) noexcept {
+  return Score(d1.mg() - d2.mg(), d1.eg() - d2.eg());
+}
+
+constexpr Score operator-(const Score d) noexcept {
+  return -d.raw();
+}
+
+constexpr Score &operator+=(Score &d1, const int d2) noexcept {
+  return d1 = d1.raw() + d2;
+}
+
+constexpr Score &operator-=(Score &d1, const int d2) noexcept {
+  return d1 = d1.raw() - d2;
+}
+
+constexpr Score &operator+=(Score &d1, const Score d2) noexcept {
+  return d1 = d1.raw() + d2.raw();
+}
+
+constexpr Score &operator-=(Score &d1, const Score d2) noexcept {
+  return d1 = d1.raw() - d2.raw();
+}
 
 /// Division of a Score must be handled separately for each term
-constexpr Score operator/(const Score s, const int i) { return Score(s.mg() / i, s.eg() / i); }
+constexpr Score operator/(const Score s, const int i) {
+  return Score(s.mg() / i, s.eg() / i);
+}
+
 Score operator*(Score, Score) = delete;
 
 /// Multiplication of a Score by an integer. We check for overflow in debug mode.
@@ -91,7 +129,9 @@ constexpr Score operator*(const Score s, const int i) {
 }
 
 /// Multiplication of a Score by a boolean
-constexpr Score operator*(const Score s, const bool b) { return b ? s : ZeroScor; }
+constexpr Score operator*(const Score s, const bool b) {
+  return b ? s : ZeroScor;
+}
 
 ///
 /// Score formatter for fmt

--- a/src/score.h
+++ b/src/score.h
@@ -1,0 +1,106 @@
+/*
+  Feliscatus, a UCI chess playing engine derived from Tomcat 1.0 (Bobcat 8.0)
+  Copyright (C) 2008-2016 Gunnar Harms (Bobcat author)
+  Copyright (C) 2017      FireFather (Tomcat author)
+  Copyright (C) 2020      Rudy Alex Kohn
+
+  Feliscatus is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Feliscatus is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <cassert>
+
+///
+/// Multi-valued type which is used to hold the mg and mg scores.
+///
+
+struct Score final {
+
+  constexpr Score(const int mg, const int eg) : value(static_cast<int>(static_cast<unsigned int>(eg) << 16) + mg) {}
+  constexpr Score(const int v) : value(v) {}
+
+  constexpr Score &operator=(const int v) noexcept {
+    value = v;
+    return *this;
+  }
+
+  constexpr bool operator==(const Score &b) const { return value == b.value; }
+
+  [[nodiscard]]
+  constexpr int eg() const noexcept {
+    const union {
+      uint16_t u;
+      int16_t s;
+    } eg = {static_cast<uint16_t>((static_cast<unsigned>(value + 0x8000) >> 16))};
+    return static_cast<int>(eg.s);
+  }
+
+  [[nodiscard]]
+  constexpr int mg() const noexcept {
+    const union {
+      uint16_t u;
+      int16_t s;
+    } mg = {static_cast<uint16_t>((static_cast<unsigned>(value)))};
+    return static_cast<int>(mg.s);
+  }
+
+  [[nodiscard]]
+  constexpr int raw() const noexcept { return value; }
+
+private:
+  int value{};
+};
+
+constexpr Score ZeroScor = Score(0);
+
+constexpr Score operator+(const Score d1, const int d2) noexcept { return d1.raw() + d2; }
+constexpr Score operator-(const Score d1, const int d2) noexcept { return d1.raw() - d2; }
+constexpr Score operator-(const Score d) noexcept { return -d.raw(); }
+constexpr Score& operator+=(Score& d1, const int d2) noexcept { return d1 = d1.raw() + d2; }
+constexpr Score& operator-=(Score& d1, const int d2) noexcept { return d1 = d1.raw() - d2; }
+constexpr Score &operator+=(Score &d1, const Score d2) noexcept { return d1 = d1.raw() + d2.raw(); }
+constexpr Score &operator-=(Score &d1, const Score d2) noexcept { return d1 = d1.raw() - d2.raw(); }
+
+/// Division of a Score must be handled separately for each term
+constexpr Score operator/(const Score s, const int i) { return Score(s.mg() / i, s.eg() / i); }
+Score operator*(Score, Score) = delete;
+
+/// Multiplication of a Score by an integer. We check for overflow in debug mode.
+constexpr Score operator*(const Score s, const int i) {
+
+  const auto result = Score(s.raw() * i);
+
+  assert(result.eg() == i * s.eg());
+  assert(result.mg() == i * s.mg());
+  assert(i == 0 || result / i == s);
+
+  return result;
+}
+
+/// Multiplication of a Score by a boolean
+constexpr Score operator*(const Score s, const bool b) { return b ? s : ZeroScor; }
+
+///
+/// Score formatter for fmt
+///
+template<>
+struct fmt::formatter<Score> : formatter<std::string_view> {
+  // parse is inherited from formatter<string_view>.
+  template<typename FormatContext>
+  auto format(const Score s, FormatContext &ctx) {
+    return formatter<std::string_view>::format(fmt::format("m:{} e:{}", s.mg(), s.eg()), ctx);
+  }
+};


### PR DESCRIPTION
- Implemented score type to hold both mg and eg values in a single int
- Refactored eval and all parameters to use new score type - which simplified it greatly
- Moved trapped rook eval from king eval to piece eval 
- Removed pseudo_legal for castleling moves in move generator